### PR TITLE
Old Java Date cleanup

### DIFF
--- a/src/main/kotlin/com/chillibits/coronaaid/CoronaAidApplication.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/CoronaAidApplication.kt
@@ -8,6 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.CommandLineRunner
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import java.time.LocalDate
+import java.time.Month
 import java.util.*
 
 @SpringBootApplication
@@ -24,7 +26,7 @@ class CoronaAidApplication: CommandLineRunner {
 	}
 
 	private fun createInfected() {
-		val birthDate = GregorianCalendar(1985, Calendar.JUNE, 4).time
+		val birthDate = LocalDate.of(1985, Month.JUNE, 4)
 		// Insert infected person
 		val infected = infectedRepository.save(
 				Infected(

--- a/src/main/kotlin/com/chillibits/coronaaid/model/db/Infected.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/model/db/Infected.kt
@@ -1,5 +1,6 @@
 package com.chillibits.coronaaid.model.db
 
+import java.time.LocalDate
 import java.util.*
 import javax.persistence.Entity
 import javax.persistence.GeneratedValue
@@ -27,8 +28,7 @@ data class Infected (
         val surname: String,
 
         // Birth date of the infected person
-        @Temporal(TemporalType.DATE)
-        val birthDate: Date,
+        val birthDate: LocalDate,
 
         // City, where the infected person lives
         val city: String,

--- a/src/main/kotlin/com/chillibits/coronaaid/model/dto/InfectedDto.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/model/dto/InfectedDto.kt
@@ -1,13 +1,14 @@
 package com.chillibits.coronaaid.model.dto
 
 import com.fasterxml.jackson.annotation.JsonManagedReference
+import java.time.LocalDate
 import java.util.*
 
 data class InfectedDto (
         val id: Int,
         val forename: String,
         val surname: String,
-        val birthDate: Date,
+        val birthDate: LocalDate,
         val city: String,
         val postalCode: Int,
         val street: String,

--- a/src/test/kotlin/com/chillibits/coronaaid/controller/v1/InfectedControllerTests.kt
+++ b/src/test/kotlin/com/chillibits/coronaaid/controller/v1/InfectedControllerTests.kt
@@ -15,6 +15,7 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Bean
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
+import java.time.LocalDate
 import java.util.*
 
 @RunWith(SpringRunner::class)
@@ -27,7 +28,7 @@ class InfectedControllerTests {
     @MockBean
     private lateinit var infectedRepository: InfectedRepository
 
-    private val testBirthDate = Date()
+    private val testBirthDate = LocalDate.now()
     private val testData = getTestData()
     private val assertData = getAssertData()
 


### PR DESCRIPTION
java.util.Date is outdated since Java 8.
New projects should use the new time library introduced with Java 8.
It is way easier to work with these new types in the future.