### PR TITLE
Add ApiOperation annotations to all RequestMappings

### DIFF
--- a/src/main/kotlin/com/chillibits/coronaaid/controller/v1/ConfigController.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/controller/v1/ConfigController.kt
@@ -4,6 +4,7 @@ import com.chillibits.coronaaid.model.dto.ConfigItemDto
 import com.chillibits.coronaaid.repository.ConfigRepository
 import com.chillibits.coronaaid.shared.toDto
 import io.swagger.annotations.Api
+import io.swagger.annotations.ApiOperation
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
@@ -21,11 +22,13 @@ class ConfigController {
             path = ["/config"],
             produces = [MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE ]
     )
+    @ApiOperation("Returns all config items")
     fun getAllConfigItems(): List<ConfigItemDto> = configRepository.findAll().map { it.toDto() }
 
     @GetMapping(
             path = ["/config/{configKey}"],
             produces = [MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE ]
     )
+    @ApiOperation("Returns a config item by its name")
     fun getSingleConfigItem(@PathVariable configKey: String): ConfigItemDto = configRepository.findByConfigKey(configKey).toDto()
 }

--- a/src/main/kotlin/com/chillibits/coronaaid/controller/v1/InfectedController.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/controller/v1/InfectedController.kt
@@ -4,6 +4,7 @@ import com.chillibits.coronaaid.model.dto.InfectedDto
 import com.chillibits.coronaaid.repository.InfectedRepository
 import com.chillibits.coronaaid.shared.toDto
 import io.swagger.annotations.Api
+import io.swagger.annotations.ApiOperation
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
@@ -20,5 +21,6 @@ class InfectedController {
             path = ["/infected"],
             produces = [MediaType.APPLICATION_JSON_VALUE , MediaType.APPLICATION_XML_VALUE ]
     )
+    @ApiOperation("Returns all infected persons with all available attributes")
     fun getAllInfected(): List<InfectedDto> = infectedRepository.findAll().map { it.toDto() }
 }

--- a/src/main/kotlin/com/chillibits/coronaaid/controller/v1/TestController.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/controller/v1/TestController.kt
@@ -6,6 +6,7 @@ import com.chillibits.coronaaid.repository.TestRepository
 import com.chillibits.coronaaid.shared.toDto
 import com.chillibits.coronaaid.shared.toModel
 import io.swagger.annotations.Api
+import io.swagger.annotations.ApiOperation
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
@@ -25,12 +26,14 @@ class TestController {
             path = ["/test"],
             produces = [MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE ]
     )
+    @ApiOperation("Returns all tests")
     fun getAllTests(): List<TestDto> = testRepository.findAll().map { it.toDto() }
 
     @GetMapping(
             path = ["/test/{infectedId}"],
             produces = [MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE]
     )
+    @ApiOperation("Returns all tests for a specific person")
     fun getTestsForSinglePerson(@PathVariable infectedId: Int): List<TestDto>
             = testRepository.findTestsForPerson(infectedId).map { it.toDto()}
 
@@ -39,5 +42,6 @@ class TestController {
             consumes = [MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE],
             produces = [MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE]
     )
+    @ApiOperation("Pushes a new test to the database")
     fun addTest(@RequestBody testDto: TestDto): Test? = testRepository.save(testDto.toModel())
 }


### PR DESCRIPTION
Replaced the method name with descriptions on the Swagger page, which are much more descriptive than the raw method name.