### PR TITLE
Add missing hashCode and equals

### DIFF
--- a/src/main/kotlin/com/chillibits/coronaaid/model/db/ConfigItem.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/model/db/ConfigItem.kt
@@ -22,4 +22,19 @@ data class ConfigItem (
 
         // Value of the key-value pair (do not name this field 'value'. This would cause an MySQL error)
         val configValue: String
-)
+) {
+        override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (javaClass != other?.javaClass) return false
+
+                other as ConfigItem
+
+                if (id != other.id) return false
+
+                return true
+        }
+
+        override fun hashCode(): Int {
+                return id
+        }
+}

--- a/src/main/kotlin/com/chillibits/coronaaid/model/db/Disease.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/model/db/Disease.kt
@@ -30,4 +30,19 @@ data class Disease (
 
         // Probability of occurrence in the wild (percentage)
         val probability: Int
-)
+) {
+        override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (javaClass != other?.javaClass) return false
+
+                other as Disease
+
+                if (id != other.id) return false
+
+                return true
+        }
+
+        override fun hashCode(): Int {
+                return id
+        }
+}

--- a/src/main/kotlin/com/chillibits/coronaaid/model/db/HistoryItem.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/model/db/HistoryItem.kt
@@ -45,4 +45,21 @@ data class HistoryItem (
         const val STATUS_REACHED = 1
         const val STATUS_FLATMATE_ANSWERED = 2
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as HistoryItem
+
+        if (id != other.id) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return id
+    }
+
+
 }

--- a/src/main/kotlin/com/chillibits/coronaaid/model/db/Infected.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/model/db/Infected.kt
@@ -75,4 +75,19 @@ data class Infected (
         @ManyToMany(mappedBy = "infected")
         val residentialGroups: Set<ResidentialGroup> = emptySet()
 
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Infected
+
+        if (id != other.id) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return id
+    }
+}

--- a/src/main/kotlin/com/chillibits/coronaaid/model/db/InitialDisease.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/model/db/InitialDisease.kt
@@ -29,4 +29,19 @@ data class InitialDisease (
 
         // Individual degree of danger (percentage)
         val degreeOfDanger: Int
-)
+) {
+        override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (javaClass != other?.javaClass) return false
+
+                other as InitialDisease
+
+                if (id != other.id) return false
+
+                return true
+        }
+
+        override fun hashCode(): Int {
+                return id
+        }
+}

--- a/src/main/kotlin/com/chillibits/coronaaid/model/db/ResidentialGroup.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/model/db/ResidentialGroup.kt
@@ -26,4 +26,19 @@ data class ResidentialGroup (
                 inverseJoinColumns = [JoinColumn(name = "group_id", referencedColumnName = "id")]
         )
         val infected: List<Infected>
-)
+) {
+        override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (javaClass != other?.javaClass) return false
+
+                other as ResidentialGroup
+
+                if (id != other.id) return false
+
+                return true
+        }
+
+        override fun hashCode(): Int {
+                return id
+        }
+}

--- a/src/main/kotlin/com/chillibits/coronaaid/model/db/Symptom.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/model/db/Symptom.kt
@@ -23,4 +23,19 @@ data class Symptom (
 
         // Probability of occurrence in the wild (percentage)
         val probability: Int
-)
+) {
+        override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (javaClass != other?.javaClass) return false
+
+                other as Symptom
+
+                if (id != other.id) return false
+
+                return true
+        }
+
+        override fun hashCode(): Int {
+                return id
+        }
+}


### PR DESCRIPTION
According to [this article](https://vladmihalcea.com/how-to-implement-equals-and-hashcode-using-the-jpa-entity-identifier/) hashCode should return a fixed number. For testing purposes I will leave it the way you see in the commit. Later I will fix this with another PR.