### PR TITLE
Fix a bug when you push a history item the infected is not unlocked

### DIFF
--- a/src/main/kotlin/com/chillibits/coronaaid/controller/v1/HistoryController.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/controller/v1/HistoryController.kt
@@ -82,7 +82,7 @@ class HistoryController {
         )
 
         // Unlock infected
-        infectedRepository.changeLockedState(infected.id, System.currentTimeMillis())
+        infectedRepository.changeLockedState(infected.id, 0)
 
         // Return stored DTO
         return item.toDto()


### PR DESCRIPTION
* The infected is not unlocked if you push a history item