### PR TITLE
Add realtime endpoint test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,10 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-websocket</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
 			<artifactId>kotlin-reflect</artifactId>
 		</dependency>

--- a/src/main/kotlin/com/chillibits/coronaaid/config/CronJobsConfig.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/config/CronJobsConfig.kt
@@ -9,12 +9,12 @@ import org.springframework.scheduling.annotation.Scheduled
 import javax.annotation.PostConstruct
 
 @Configuration
-class CronJobs {
+class CronJobsConfig {
 
     @Autowired
     private lateinit var infectedRepository: InfectedRepository
 
-    val log: Logger = LoggerFactory.getLogger(CronJobs::class.java)
+    val log: Logger = LoggerFactory.getLogger(CronJobsConfig::class.java)
 
     @PostConstruct
     public fun onStartup() {

--- a/src/main/kotlin/com/chillibits/coronaaid/config/WebSocketConfig.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/config/WebSocketConfig.kt
@@ -1,0 +1,14 @@
+package com.chillibits.coronaaid.config
+
+import com.chillibits.coronaaid.shared.SocketTextHandler
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.socket.config.annotation.EnableWebSocket
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
+
+@Configuration
+@EnableWebSocket
+class WebSocketConfig {
+    fun registerWebSocketHandlers(registry: WebSocketHandlerRegistry) {
+        registry.addHandler(SocketTextHandler(), "/infected/realtime")
+    }
+}

--- a/src/main/kotlin/com/chillibits/coronaaid/shared/SocketTextHandler.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/shared/SocketTextHandler.kt
@@ -9,6 +9,6 @@ import org.springframework.web.socket.handler.TextWebSocketHandler
 class SocketTextHandler: TextWebSocketHandler() {
     override fun handleTextMessage(session: WebSocketSession, message: TextMessage) {
         println(message.payload)
-        session.sendMessage(TextMessage("This is a test answer"))
+        session.sendMessage(TextMessage("<message>This is a test answer</message>"))
     }
 }

--- a/src/main/kotlin/com/chillibits/coronaaid/shared/SocketTextHandler.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/shared/SocketTextHandler.kt
@@ -1,0 +1,14 @@
+package com.chillibits.coronaaid.shared
+
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.TextMessage
+import org.springframework.web.socket.WebSocketSession
+import org.springframework.web.socket.handler.TextWebSocketHandler
+
+@Component
+class SocketTextHandler: TextWebSocketHandler() {
+    override fun handleTextMessage(session: WebSocketSession, message: TextMessage) {
+        println(message.payload)
+        session.sendMessage(TextMessage("This is a test answer"))
+    }
+}


### PR DESCRIPTION
Added a test endpoint for realtime communication with the frontend via web sockets. The endpoint is temporary available at "/infected/realtime". Up to now, the endpoint only returns a generic test answer. I will implement further functionality after a successful test.

@keksklauer4 Please test the feature in the frontend and notify us, if it's working