### PR TITLE
Add additional fields to InfectedCompressedDto

### DIFF
--- a/src/main/kotlin/com/chillibits/coronaaid/model/dto/InfectedCompressedDto.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/model/dto/InfectedCompressedDto.kt
@@ -1,14 +1,29 @@
 package com.chillibits.coronaaid.model.dto
 
+import java.time.Instant
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
 data class InfectedCompressedDto(
         val id: Int,
+        val age : Long,
         val forename: String,
         val surname: String,
         val lat: Double,
         val lon: Double,
         val phone: String?,
-        val timestampCallToday: Long?,
+        val done : Boolean,
+        val lastUnsuccessfulCallToday: Long?,
         val personalFeeling: Int?,
         val sumInitialDiseases: Int?,
         val sumSymptoms: Int?
-)
+) {
+    var lastUnsuccessfulCallTodayString : String? = lastUnsuccessfulCallToday?.let {
+        LocalTime.ofInstant(Instant.ofEpochMilli(lastUnsuccessfulCallToday), ZoneId.systemDefault()).format(TIME_FORMATTER)
+    }
+
+    companion object {
+        @JvmField val TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+    }
+}

--- a/src/main/kotlin/com/chillibits/coronaaid/model/dto/InfectedDto.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/model/dto/InfectedDto.kt
@@ -1,7 +1,7 @@
 package com.chillibits.coronaaid.model.dto
 
+import com.chillibits.coronaaid.shared.yearsBetween
 import java.time.LocalDate
-import java.time.temporal.ChronoUnit
 
 data class InfectedDto (
         val id: Int,
@@ -21,5 +21,5 @@ data class InfectedDto (
         val historyItems: Set<HistoryItemDto>,
         val residentialGroups: Set<ResidentialGroupDto>
 ) {
-        val age = ChronoUnit.YEARS.between(this.birthDate, LocalDate.now())
+        val age = this.birthDate.yearsBetween(LocalDate.now())
 }

--- a/src/main/kotlin/com/chillibits/coronaaid/shared/ModelToDtoMappers.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/shared/ModelToDtoMappers.kt
@@ -45,7 +45,7 @@ fun Infected.toCompressed(): InfectedCompressedDto {
     val lastSuccessfulCall = sortedHistory.filter { it.status == HistoryItem.STATUS_REACHED }.firstOrNull()
 
     val latestMidnight = Instant.now().truncatedTo(ChronoUnit.DAYS).toEpochMilli()
-    val todayTimestamp = sortedHistory.filter { it.timestamp >= latestMidnight && it.status == HistoryItem.STATUS_REACHED }.map { it.timestamp }.firstOrNull()
+    val todayTimestamp = sortedHistory.filter { it.timestamp >= latestMidnight && it.status == HistoryItem.STATUS_NOT_REACHABLE }.map { it.timestamp }.firstOrNull()
 
     return InfectedCompressedDto(
             id = this.id,

--- a/src/test/kotlin/com/chillibits/coronaaid/controller/v1/InfectedControllerTests.kt
+++ b/src/test/kotlin/com/chillibits/coronaaid/controller/v1/InfectedControllerTests.kt
@@ -41,7 +41,7 @@ class InfectedControllerTests {
     @MockBean
     private lateinit var configRepository: ConfigRepository
 
-    private val testBirthDate = LocalDate.now()
+    private val testBirthDate = LocalDate.of(2000, 2, 7)
     private val testTimestamp = System.currentTimeMillis()
     private val testData = getTestData()
     private val assertData = getAssertData()
@@ -166,10 +166,10 @@ class InfectedControllerTests {
     }
 
     private fun getCompressedAssertData(): Set<InfectedCompressedDto> {
-        val compressed1 = InfectedCompressedDto(0, "John", "Doe", 49.0264134, 8.3831085, null,
-                                                null, 6, 0, 0)
-        val compressed2 = InfectedCompressedDto(1, "Joe", "Dalton", 49.4874639, 8.4763718, null,
-                                                null, null, 0, null)
+        val compressed1 = InfectedCompressedDto(0, 20,"John", "Doe", 49.0264134, 8.3831085, null,
+                                                false, null, 6, 0, 0)
+        val compressed2 = InfectedCompressedDto(1, 20, "Joe", "Dalton", 49.4874639, 8.4763718, null,
+                                                false, null, null, 0, null)
         return setOf(compressed1, compressed2)
     }
 }


### PR DESCRIPTION
* the done flag is true when the infected have already been called successfully today, otherwise false
* added age field to the compressed DTO
* the timestamp is now converted to a string with the format HH:mm (hours:minutes). Stored in an extra field
* todayTimestamp is now null if no successful call for the current day was found
* renamed todayTimestamp to todayUnsuccessfulTimestamp
