### PR TITLE
Add routine to generate HistoryItems at midnight (Fix #107)

### DIFF
--- a/src/main/kotlin/com/chillibits/coronaaid/config/CronJobsConfig.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/config/CronJobsConfig.kt
@@ -1,7 +1,13 @@
 package com.chillibits.coronaaid.config
 
+import com.chillibits.coronaaid.model.db.HistoryItem
+import com.chillibits.coronaaid.model.db.Symptom
 import com.chillibits.coronaaid.repository.ConfigRepository
+import com.chillibits.coronaaid.repository.HistoryRepository
+import com.chillibits.coronaaid.repository.InfectedRepository
+import com.chillibits.coronaaid.repository.SymptomRepository
 import com.chillibits.coronaaid.repository.TestRepository
+import com.chillibits.coronaaid.service.InfectedService
 import com.chillibits.coronaaid.shared.ConfigKeys
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -11,6 +17,7 @@ import org.springframework.scheduling.TaskScheduler
 import org.springframework.scheduling.annotation.Scheduled
 import java.time.Duration
 import javax.annotation.PostConstruct
+import kotlin.random.Random
 
 @Configuration
 class CronJobsConfig {
@@ -20,6 +27,15 @@ class CronJobsConfig {
 
     @Autowired
     private lateinit var configRepository: ConfigRepository
+
+    @Autowired
+    private lateinit var infectedService: InfectedService
+
+    @Autowired
+    private lateinit var symptomRepository: SymptomRepository
+
+    @Autowired
+    private lateinit var historyRepository: HistoryRepository
 
     @Autowired
     private lateinit var taskScheduler: TaskScheduler
@@ -43,11 +59,36 @@ class CronJobsConfig {
   
     @Scheduled(cron = "0 0 0 * * ?")
     fun dailyEvaluation() {
-        log.info("Daily evaluation started.")
+        log.info("Daily cron started.")
 
         // Evaluate all pending tests
         testRepository.evaluateAllPendingTests()
 
-        log.info("Daily evaluation finished.")
+        // Generate fake history items for test purposes
+        generateFakeHistoryItems()
+
+        log.info("Daily cron finished.")
     }
+
+    private fun generateFakeHistoryItems() {
+        // Get random infected
+        val infected = infectedService.findAllEagerly()
+        val randomInfected = infected.filterIndexed { idx, _ -> idx % 2 == 0 }
+
+        // Load all symptoms
+        //val symptoms = symptomRepository.findAll()
+
+        randomInfected.forEach {
+            // Generate set of 0 to 5 random symptoms
+            //val symptomSet = symptoms.filter { rand(1, 5) == 4 }.toSet()
+            // Random status
+            val status = rand(0, 2)
+            // Random personal feeling
+            val personalFeeling = rand(0, 10)
+            // Create history item
+            historyRepository.save(HistoryItem(0, it, System.currentTimeMillis(), emptySet(), status, personalFeeling))
+        }
+    }
+
+    private fun rand(start: Int, end: Int) = Random(System.nanoTime()).nextInt(end - start + 1) + start
 }

--- a/src/main/kotlin/com/chillibits/coronaaid/repository/InfectedRepository.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/repository/InfectedRepository.kt
@@ -38,5 +38,4 @@ interface InfectedRepository: JpaRepository<Infected, Int> {
     @Transactional
     @Query("UPDATE Infected i SET i.lockedTimestamp = ?2 WHERE i.id = ?1")
     fun changeLockedState(infectedId: Int, timestamp: Long)
-  
 }

--- a/src/main/kotlin/com/chillibits/coronaaid/service/InfectedService.kt
+++ b/src/main/kotlin/com/chillibits/coronaaid/service/InfectedService.kt
@@ -18,9 +18,9 @@ class InfectedService {
     private lateinit var applicationEventPublisher: ApplicationEventPublisher
 
     fun findById(infectedId: Int) = infectedRepository.findById(infectedId)
-    fun findAllEagerly(): Set<Infected> = infectedRepository.findAllEagerly()
+    fun findAllEagerly() = infectedRepository.findAllEagerly()
     fun findAllEagerly(infected: Set<Int>) = infectedRepository.findAllEagerly(infected)
-    fun findAllLockedSince(timestamp: Long, configAutoResetOffset: Long, refreshInterval: Long): Set<Int> = infectedRepository.findAllLockedSince(timestamp, configAutoResetOffset, refreshInterval)
+    fun findAllLockedSince(timestamp: Long, configAutoResetOffset: Long, refreshInterval: Long) = infectedRepository.findAllLockedSince(timestamp, configAutoResetOffset, refreshInterval)
 
     @Transactional
     fun changeLockedState(infectedId: Int, timestamp: Long) {


### PR DESCRIPTION
CronJob for generating HistoryItems for 50% of the infected persons every day (running at midnight).
Currently, the HistoryItems do not contain symptoms.